### PR TITLE
Handle changes to the active timeseries on a job better

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190530013331-054be550cb49 // indirect
 	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
 	github.com/signalfx/golib v2.4.0+incompatible
-	github.com/signalfx/signalfx-go v1.5.1-0.20190811203807-25aad08a096f
+	github.com/signalfx/signalfx-go v1.6.2-0.20190829204208-2874a19e3897
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,10 @@ github.com/signalfx/signalfx-go v1.5.1-0.20190811203807-25aad08a096f h1:whMfU2OW
 github.com/signalfx/signalfx-go v1.5.1-0.20190811203807-25aad08a096f/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
 github.com/signalfx/signalfx-go v1.5.1 h1:bsxqPwDiYrREOYoORu6OLPhi604voYaJGFsU63rgVI0=
 github.com/signalfx/signalfx-go v1.5.1/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
+github.com/signalfx/signalfx-go v1.6.2-0.20190829183319-2a560a6947b9 h1:Y0FDlIGpRTVy/J/vvZ0RC0uY1N3O7v6Yepki90JOEIM=
+github.com/signalfx/signalfx-go v1.6.2-0.20190829183319-2a560a6947b9/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
+github.com/signalfx/signalfx-go v1.6.2-0.20190829204208-2874a19e3897 h1:QQ2OW7S4OXwab/NC/TbWmT8V9vlxflTub07YUvIBKbc=
+github.com/signalfx/signalfx-go v1.6.2-0.20190829204208-2874a19e3897/go.mod h1:0Q0eueMWMC8r+jq+LJIGrspzvLF+hpWO9cggHlSpwVs=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -100,7 +100,7 @@ func (r *Registry) HPAMetricMatchingKey(m *HPAMetric) *HPAMetric {
 	return r.metricsByKey[m.Key()]
 }
 
-func (r *Registry) LatestSnapshot(m *HPAMetric) (*MetricSnapshot, error) {
+func (r *Registry) LatestSnapshot(m *HPAMetric) (MetricSnapshot, error) {
 	return r.jobRunner.LatestSnapshot(m)
 }
 


### PR DESCRIPTION
Previously it was assuming all data for a compuatation came in on a
single data message, which was a bad assumption.

It will now update the snapshot incrementally and clean up any
timeseries that haven't reported for three times their resolution.