### PR TITLE
sanitize labels so it replaces / or . with _

### DIFF
--- a/internal/resources.go
+++ b/internal/resources.go
@@ -42,6 +42,10 @@ type HPAMetric struct {
 	HPAResource autoscaling.CrossVersionObjectReference
 }
 
+var propNameSanitizer = strings.NewReplacer(
+	".", "_",
+	"/", "_")
+
 // IsExternal returns true if this metric is an external (not custom) metric.
 func (m *HPAMetric) IsExternal() bool {
 	return m.Program != ""
@@ -108,7 +112,7 @@ func filtersFromSelector(selector labels.Selector) ([]string, error) {
 		if req.Operator() != selection.Equals {
 			return nil, fmt.Errorf("unsupported selector operator in selector '%v'", selector)
 		}
-		filters = append(filters, fmt.Sprintf(`filter("%s", "%s")`, req.Key(), req.Values().List()[0]))
+		filters = append(filters, fmt.Sprintf(`filter("%s", "%s")`, propNameSanitizer.Replace(req.Key()), req.Values().List()[0]))
 	}
 	return filters, nil
 }

--- a/internal/resources_test.go
+++ b/internal/resources_test.go
@@ -24,11 +24,11 @@ func TestHPAMetricPrograms(t *testing.T) {
 				}),
 				PodSelector: forceLabelSelector(&metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"app": "myapp",
+						"example.com/app": "myapp",
 					},
 				}),
 			},
-			expectedProgram: `data("my_metric", filter=filter("app", "myapp") and filter("verb", "GET") and filter("kubernetes_namespace", "default")).publish()`,
+			expectedProgram: `data("my_metric", filter=filter("example_com_app", "myapp") and filter("verb", "GET") and filter("kubernetes_namespace", "default")).publish()`,
 		},
 		{
 			metric: HPAMetric{


### PR DESCRIPTION
**Summay**
Both Yelp's own collector and signalfx-agent replaces '/' or '.' with '_' . I think the adapter should do it as well. Otherwise our labels like 'yelp.com/xx' doesn't work.  