### PR TITLE
Update examples to use the current autoscaling API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ namespace** due to how Kubernetes queries the adapter for them.
 ## Example HPA
 
 ```yaml
-
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:
@@ -34,17 +33,23 @@ metadata:
 spec:
   maxReplicas: 10
   metrics:
-  - pods:
-      metricName: nginx_requests
-      selector:
-        matchLabels:
-          plugin: nginx
-      targetAverageValue: "100"
-    type: Pods
-  - external:
-      metricName: job_lag_seconds
-      targetAverageValue: "10"
-    type: External
+  - type: Pods
+    pods:
+      metric:
+        name: nginx_requests
+        selector:
+          matchLabels:
+            plugin: nginx
+      target:
+        type: AverageValue
+        averageValue: "100"
+  - type: External
+    external:
+      metric:
+        name: job_lag_seconds
+      target:
+        type: AverageValue
+        averageValue: "10"
   minReplicas: 5
   scaleTargetRef:
     apiVersion: extensions/v1beta1
@@ -122,7 +127,7 @@ example, if you have an HPA on a work queue service and wanted to scale based
 on the maximum size of the queue in any single worker pod:
 
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:
@@ -132,10 +137,13 @@ metadata:
 spec:
   maxReplicas: 10
   metrics:
-  - external:
-      metricName: queue_size
-      targetValue: "500"
-    type: External
+  - type: External
+    external:
+      metric:
+        name: queue_size
+      target:
+        type: AverageValue
+        averageValue: "500"
   minReplicas: 5
   scaleTargetRef:
     apiVersion: extensions/v1beta1

--- a/example/resources.yaml
+++ b/example/resources.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:
@@ -12,13 +12,16 @@ spec:
   minReplicas: 1
   maxReplicas: 10
   metrics:
-  - pods:
-      metricName: nginx_requests
-      selector:
-        matchLabels:
-          plugin: nginx
-      targetAverageValue: "100"
-    type: Pods
+  - type: Pods
+    pods:
+      metric:
+        name: nginx_requests
+        selector:
+          matchLabels:
+            plugin: nginx
+      target:
+        type: AverageValue
+        averageValue: "100"
   scaleTargetRef:
     apiVersion: extensions/v1beta1
     kind: Deployment


### PR DESCRIPTION
There are some structural changes to the HPA objects required to support the most recent version of the HorizontalPodAutoscaler running on autoscaling/v2beta2.

This PR aims to address these structural changes to save other times as the documentation linked in the ReadMe references documentation using the v2beta2.

This has been tested on Kubernetes version 1.15.2 for all 3 examples that have been updated.