### PR TITLE
Add Support to Use Private Docker Image

### DIFF
--- a/deployments/helm/signalfx-k8s-metrics-adapter/templates/deployment.yaml
+++ b/deployments/helm/signalfx-k8s-metrics-adapter/templates/deployment.yaml
@@ -64,3 +64,7 @@ spec:
       volumes:
       - name: temp-vol
         emptyDir: {}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets }}
+      {{- end }}


### PR DESCRIPTION
## Background
Add `imagePullSecrets` attribute to the deployment so that users are able pull images from a private container repository but can still continue using the community Helm chart.  (eg. Use a multi-arch docker image of the metrics adapter)