### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.
+
 # SignalFx Kubernetes Metrics Adapter
 
 This is a custom metrics adapter that allows using SignalFx metrics in a


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.