### PR TITLE
Update autoscaling api version for k8s v1.26+

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ namespace** due to how Kubernetes queries the adapter for them.
 ## Example HPA
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:
@@ -129,7 +129,7 @@ example, if you have an HPA on a work queue service and wanted to scale based
 on the maximum size of the queue in any single worker pod:
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:

--- a/example/custom-object-hpa.yaml
+++ b/example/custom-object-hpa.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:

--- a/example/custom-pod-hpa.yaml
+++ b/example/custom-pod-hpa.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:

--- a/example/external-hpa.yaml
+++ b/example/external-hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:

--- a/internal/hpas.go
+++ b/internal/hpas.go
@@ -12,7 +12,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/sfxclient"
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -56,7 +56,7 @@ func NewHPADiscoverer(client kubernetes.Interface, updateCallback HPACallback, d
 }
 
 func (d *HPADiscoverer) Discover(ctx context.Context) {
-	watchList := cache.NewListWatchFromClient(d.client.AutoscalingV2beta2().RESTClient(), "horizontalpodautoscalers", "", fields.Everything())
+	watchList := cache.NewListWatchFromClient(d.client.AutoscalingV2().RESTClient(), "horizontalpodautoscalers", "", fields.Everything())
 
 	_, controller := cache.NewInformer(
 		watchList,

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/signalfx/signalfx-go/signalflow/messages"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv1 "k8s.io/api/autoscaling/v2"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -198,7 +198,7 @@ func TestPodMetrics(t *testing.T) {
 	_, err = k8sClient.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.Nil(t, err)
 
-	hpa, err = k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
+	hpa, err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
 	require.Nil(t, err)
 
 	tsids := []idtool.ID{idtool.ID(rand.Int63()), idtool.ID(rand.Int63())}
@@ -370,7 +370,7 @@ func TestPodMetrics(t *testing.T) {
 
 	// DELETE THE HPA
 
-	err = k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Delete(ctx, hpa.Name, metav1.DeleteOptions{})
+	err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Delete(ctx, hpa.Name, metav1.DeleteOptions{})
 	require.Nil(t, err)
 
 	require.True(t, waitFor(5*time.Second, func() bool {
@@ -434,7 +434,7 @@ func TestObjectMetrics(t *testing.T) {
 	_, err := k8sClient.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.Nil(t, err)
 
-	_, err = k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
+	_, err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
 	require.Nil(t, err)
 
 	tsid := idtool.ID(rand.Int63())
@@ -544,7 +544,7 @@ func TestExternalMetrics(t *testing.T) {
 	_, err := k8sClient.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.Nil(t, err)
 
-	_, err = k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
+	_, err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
 	require.Nil(t, err)
 
 	var metric *external_metrics.ExternalMetricValueList
@@ -654,7 +654,7 @@ func TestCustomMetricWhitelist(t *testing.T) {
 	_, err = k8sClient.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.Nil(t, err)
 
-	_, err = k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
+	_, err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
 	require.Nil(t, err)
 
 	tsids := []idtool.ID{idtool.ID(rand.Int63()), idtool.ID(rand.Int63())}
@@ -810,7 +810,7 @@ func TestRestartJobOnSignalFlowError(t *testing.T) {
 	_, err := k8sClient.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.Nil(t, err)
 
-	_, err = k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
+	_, err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
 	require.Nil(t, err)
 
 	var metric *external_metrics.ExternalMetricValueList
@@ -906,7 +906,7 @@ func TestMultipleHPAs(t *testing.T) {
 		_, err := k8sClient.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 		require.Nil(t, err)
 
-		_, err = k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
+		_, err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
 		require.Nil(t, err)
 
 		tsids := []idtool.ID{idtool.ID(rand.Int63()), idtool.ID(rand.Int63())}
@@ -1043,7 +1043,7 @@ func TestMinimumExpiry(t *testing.T) {
 	_, err = k8sClient.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	require.Nil(t, err)
 
-	hpa, err = k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
+	hpa, err = k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Create(ctx, hpa, metav1.CreateOptions{})
 	require.Nil(t, err)
 
 	tsids := []idtool.ID{idtool.ID(rand.Int63()), idtool.ID(rand.Int63())}
@@ -1121,14 +1121,14 @@ func waitFor(timeout time.Duration, f func() bool) bool {
 // Retries on 409 errors
 func updateHPA(ctx context.Context, k8sClient kubernetes.Interface, name string, updater func(hpa *autoscalingv1.HorizontalPodAutoscaler)) (*autoscalingv1.HorizontalPodAutoscaler, error) {
 	for {
-		hpa, err := k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Get(ctx, name, metav1.GetOptions{})
+		hpa, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 
 		updater(hpa)
 
-		newHPA, err := k8sClient.AutoscalingV2beta2().HorizontalPodAutoscalers(testNamespace).Update(ctx, hpa, metav1.UpdateOptions{})
+		newHPA, err := k8sClient.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Update(ctx, hpa, metav1.UpdateOptions{})
 		if err != nil {
 			if se, ok := err.(*apierrors.StatusError); ok {
 				if se.Status().Code == 409 {

--- a/internal/resources.go
+++ b/internal/resources.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"


### PR DESCRIPTION
Hey there, [k8s v1.26](https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-the-v2beta2-horizontalpodautoscaler-api) removes the v2beta2 autoscaling api. When upgrading to 1.26+, the metrics adapter stops functioning

This PR updates the adapter to use the `v2` version of the autoscaling API.