### PR TITLE
Add timeout for signalflow metadata request

### DIFF
--- a/internal/job_runner.go
+++ b/internal/job_runner.go
@@ -108,7 +108,9 @@ func (jr *SignalFlowJobRunner) ReplaceOrStartJob(ctx context.Context, program st
 
 	// Wait for the handle to come through before sending the message to block
 	// the loop less.
-	handle, err := comp.Handle(ctx)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, jr.MetadataTimeout)
+	handle, err := comp.Handle(ctxWithTimeout)
+	cancel()
 	if err != nil {
 		// It's possible that the job has already started but the server was delayed sending the handle
 		// to avoid leaking jobs, issue delete using the channel name, ie: detach.


### PR DESCRIPTION
I've found that if an external metrics SignalFlow query is defined with errors it will cause the API to hang, ultimately causing the entire external metrics API to fail for all HPAs.

The timeout seems to have been removed in https://github.com/signalfx/signalfx-k8s-metrics-adapter/pull/32. This adds it back in and allows for the API to continue functioning even if there's a bad query defined.