### PR TITLE
[chore] Update golang version and centralize its definition

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -13,7 +13,6 @@ env:
   REGISTRY: "quay.io/signalfx"
   IMAGE_NAME: "k8s-metrics-adapter"
   IMAGE_VERSION: "latest"
-  GO_VERSION: "1.20.3"
   MINIKUBE_VERSION: "v1.28.0"
   HELM_VERSION: "v3.9.0"
 

--- a/.github/workflows/k8s-test.yml
+++ b/.github/workflows/k8s-test.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         K8S_VERSION: [ "v1.23.0",  "v1.24.0", "v1.25.0", "v1.26.0" ]
     env:
-      GO_VERSION: "1.20.3"
       MINIKUBE_VERSION: v1.31.1
 
     steps:
@@ -27,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Cache go dependencies
         uses: actions/cache@v3
@@ -36,7 +35,7 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
             ~/go/bin
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('go.mod', '**/go.sum') }}
 
       - name: Cache kubectl
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.20 as builder
+ARG GO_VERSION=1.26.4
+FROM golang:${GO_VERSION} AS builder
 
 # upgrade to get latest root CA
 RUN apt-get update && \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ REGISTRY?=quay.io/signalfx
 IMAGE?=k8s-metrics-adapter
 ARCH?=amd64
 OS?=linux
+GO_VERSION?=$(shell awk '/^go / { print $$2; exit }' go.mod)
 
 VERSION?=latest
 
@@ -15,5 +16,5 @@ test:
 	CGO_ENABLED=0 go test -v ./cmd/... ./internal/...
 
 image:
-	docker build -t $(REGISTRY)/$(IMAGE):$(VERSION) .
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t $(REGISTRY)/$(IMAGE):$(VERSION) .
 	if [[ "$(PUSH)" == "yes" ]]; then docker push $(REGISTRY)/$(IMAGE):$(VERSION); fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/signalfx-k8s-metrics-adapter
 
-go 1.20
+go 1.26.4
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
To updated various dependencies it is necessary to update the current golang toolchain. This PR updates it to latest and centralizes the definition as much as possible.